### PR TITLE
feat: win condition logic and result display

### DIFF
--- a/console_display.py
+++ b/console_display.py
@@ -8,3 +8,14 @@ def display_all_hands(hands):
         print(f'\n{hand["name"]}')
         print(f'Hand: {hand["cards"]}')
         print(f'Number of Pairs: {hand["pairs"]}')
+
+def display_all_winners(winning_hands):
+    number_of_winners = len(winning_hands)
+    if number_of_winners == 0:
+        print('No players had one or more pairs in their hand.')
+    elif number_of_winners == 1:
+        print(f'\n{winning_hands[0]["name"]} has won with {winning_hands[0]["pairs"]} pair(s)!')
+    else:
+        print(f'\nThere was a {number_of_winners}-way tie between the below players with {winning_hands[0]["pairs"]} pair(s)!')
+        for hand in winning_hands:
+            print(hand['name'])

--- a/main.py
+++ b/main.py
@@ -12,7 +12,8 @@ def main():
     deal_cards(all_hands, cards_per_hand, deck)
     determine_pairs_in_hands(all_hands)
     console_display.display_all_hands(all_hands)
-    #determine and display the winner(s)
+    winners = determine_hand_winners(all_hands)
+    console_display.display_all_winners(winners)
 
 def generate_deck(type_repetitions):
     card_types = ['ace', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'jack', 'queen', 'king']
@@ -51,5 +52,17 @@ def determine_pairs_in_hands(hands):
             if len([index for index, card_from_hand in enumerate(hand['cards']) if card_from_hand == card])  > 1:
                 hands[index]['pairs'] += 1
 
+def determine_hand_winners(hands):
+    winning_number_of_pairs = find_max_pairs(hands)
+    if winning_number_of_pairs == 0:
+        return []
+    return [hand for hand in hands if hand['pairs'] == winning_number_of_pairs]
+
+def find_max_pairs(hands):
+    max_pairs = 0
+    for hand in hands:
+        if hand['pairs'] > max_pairs:
+            max_pairs = hand ['pairs']
+    return max_pairs
 
 main()


### PR DESCRIPTION
Adds logic to determine the maximum number of pairs in any current hand, and return all hands with that number of pairs as winners. The winning hand names will be displayed to the console along with how many pairs they had and a note about any ties. If no hands had pairs, the message will display with no hand names.